### PR TITLE
🔧 Recovery: Apply v0.2.0 version bump from failed release

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "injx"
-version = "0.1.0"
+version = "0.2.0"
 description = "Type-safe dependency injection for Python 3.13+"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.13"


### PR DESCRIPTION
## Recovery PR for v0.2.0 Release

### Background
The v0.2.0 release workflow successfully published to PyPI on Sept 21, but the post-release actions failed, leaving:
- ✅ Package published to PyPI
- ❌ No Git tag created 
- ❌ Version bump not merged to main
- 🔶 Orphaned branch with correct version

### What This PR Does
Merges the version bump from the orphaned `release/pypi-v0.2.0` branch to align the repository with PyPI.

### Changes
- Updates `pyproject.toml` version from `0.1.0` to `0.2.0`

### Verification
- PyPI: https://pypi.org/project/injx/0.2.0/
- Published: 2025-09-21 09:23:41 UTC

### Notes
- The v0.2.0 tag cannot be pushed due to repository rules, but will be created after merge
- This is a recovery action to fix the failed workflow from run [#17887425193](https://github.com/QriusGlobal/injx/actions/runs/17887425193)

### Post-Merge Actions Required
1. Create v0.2.0 tag on the merged commit
2. Create GitHub release for v0.2.0
3. Verify semantic-release can calculate next version correctly