### PR TITLE
feat(container): add Pythonic subscript syntax for dependency resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Features
 
+- Pythonic subscript access syntax (`container[Token]`) for dependency resolution
+  - Subscript access support in Container, TestContainer, and TestScope classes
+  - Type-safe overloads for subscript access with full IDE autocomplete support
+  - Equivalent to `container.get(token)` for synchronous resolution
+  - For async resolution, continue using `await container.aget(token)`
 - `Dependencies` pattern for grouping multiple dependencies (#PRD-003)
 - `Container.get_active()` and `Container.set_active()` class methods (#PRD-001)
 - `ContainerProtocol` for type-safe contracts (#PRD-002)

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ def get_user_info(
     This follows modern Python patterns used by FastAPI and Pydantic.
     """
     # Extract services from dependencies container
+    # Traditional method syntax
     db = deps[Database]
     http = deps[HTTPClient]
     cache = deps[Cache]
@@ -247,6 +248,10 @@ Service registry that manages registration and resolution:
 ```python
 container = Container()
 container.register(DB_TOKEN, PostgresDatabase, scope=Scope.SINGLETON)
+
+# Resolve dependencies - two equivalent syntaxes
+db = container.get(DB_TOKEN)     # Explicit method syntax
+db = container[DB_TOKEN]         # Pythonic subscript syntax (recommended)
 ```
 
 ### @inject Decorator with Dependencies Pattern

--- a/src/injx/container.py
+++ b/src/injx/container.py
@@ -50,9 +50,9 @@ from .exceptions import (
     CircularDependencyError,
     ResolutionError,
 )
-from .protocols.container import ContainerProtocol, TestScopeProtocol
 from .logging import log_performance_metric, log_resolution_path, logger
 from .metaclasses import Injectable
+from .protocols.container import TestScopeProtocol
 from .protocols.resources import SupportsAsyncClose, SupportsClose
 from .provider_spec import ProviderSpec
 from .registry import TypedRegistry
@@ -161,6 +161,10 @@ class Container:
         LOGGER = Token[Logger]("logger")
         container.register_singleton(LOGGER, ConsoleLogger)
 
+        # Resolve dependencies using either syntax
+        logger = container.get(LOGGER)        # Explicit method syntax
+        logger = container[LOGGER]            # Pythonic subscript syntax
+
         @inject
         def handler(logger: Inject[Logger]):
             logger.info("hello")
@@ -168,7 +172,9 @@ class Container:
     Testing Example:
         with container.test_scope() as test:
             test.override(LOGGER, MockLogger())
+            # Both syntaxes work in test scope
             service = test.get(MyService)
+            service = test[MyService]
             # Test with isolated dependencies
     """
 
@@ -740,6 +746,41 @@ class Container:
                 "resolve", duration_ms, {"token": token.name, "scope": token.scope.name}
             )
             return result
+
+    @overload
+    def __getitem__(self, token: Token[U]) -> U: ...
+
+    @overload
+    def __getitem__(self, token: type[U]) -> U: ...
+
+    def __getitem__(self, token: Token[U] | type[U]) -> U:
+        """Resolve a dependency using subscript syntax.
+
+        Provides Pythonic syntax for dependency resolution:
+            db = container[Database]
+
+        This is equivalent to container.get() and provides type-safe
+        access to registered dependencies.
+
+        Args:
+            token: The Token[T] or type[T] to resolve.
+
+        Returns:
+            The resolved instance.
+
+        Raises:
+            ResolutionError: If no provider is registered or resolution fails.
+
+        Note:
+            For async resolution, use `await container.aget(token)` instead.
+            Subscript access is synchronous only.
+
+        Example:
+            >>> container = Container()
+            >>> container.register(Database, PostgresDatabase)
+            >>> db = container[Database]  # Type-safe subscript access
+        """
+        return self.get(token)
 
     def _resolve_fast_path(self, token: Token[U] | type[U]) -> U | None:
         """Attempt fast resolution for cached or given instances.

--- a/src/injx/protocols/container.py
+++ b/src/injx/protocols/container.py
@@ -74,6 +74,30 @@ class ContainerProtocol(Protocol):
         ...
 
     @overload
+    def __getitem__(self, token: Token[T]) -> T: ...
+
+    @overload
+    def __getitem__(self, token: type[T]) -> T: ...
+
+    def __getitem__(self, token: Token[T] | type[T]) -> T:
+        """Resolve a dependency using subscript syntax.
+
+        Args:
+            token: Token or type for the dependency to resolve
+
+        Returns:
+            The resolved dependency instance
+
+        Raises:
+            ResolutionError: If the dependency cannot be resolved
+            CircularDependencyError: If a circular dependency is detected
+
+        Example:
+            db = container[Database]
+        """
+        ...
+
+    @overload
     def register(
         self,
         token: Token[T],
@@ -318,6 +342,17 @@ class TestScopeProtocol(Protocol):
 
     def get(self, token: Token[T] | type[T]) -> T:
         """Get a dependency, applying overrides first.
+
+        Args:
+            token: Token or type to resolve
+
+        Returns:
+            The resolved instance with overrides applied
+        """
+        ...
+
+    def __getitem__(self, token: Token[T] | type[T]) -> T:
+        """Get a dependency using subscript syntax.
 
         Args:
             token: Token or type to resolve

--- a/src/injx/testing.py
+++ b/src/injx/testing.py
@@ -132,6 +132,17 @@ class TestContainer:
         # Fall back to base container
         return self.base_container.get(normalized_token)
 
+    def __getitem__(self, token: Token[T] | type[T]) -> T:
+        """Get a dependency using subscript syntax, applying overrides first.
+
+        Args:
+            token: The token or type to resolve
+
+        Returns:
+            The resolved instance with overrides applied
+        """
+        return self.get(token)
+
     async def aget(self, token: Token[T] | type[T]) -> T:
         """Async version of get.
 
@@ -179,6 +190,43 @@ class TestScope:
         self.container = container
         self._context_manager: Any = None
         self._async_context_manager: Any = None
+
+    def get(self, token: Token[T] | type[T]) -> T:
+        """Delegate get to container."""
+        return self.container.get(token)
+
+    def override(self, token: Token[T] | type[T], mock: T | Callable[[], T]) -> None:
+        """Delegate override to container."""
+        if hasattr(self.container, "override"):
+            self.container.override(token, mock)
+
+    def mock(
+        self, token: Token[T] | type[T], implementation: Callable[[], T] | None = None
+    ) -> None:
+        """Delegate mock to container."""
+        if hasattr(self.container, "mock"):
+            self.container.mock(token, implementation)
+
+    async def aget(self, token: Token[T] | type[T]) -> T:
+        """Delegate async get to container."""
+        if hasattr(self.container, "aget"):
+            return await self.container.aget(token)
+        return self.container.get(token)
+
+    def clear_overrides(self) -> None:
+        """Delegate clear_overrides to container."""
+        if hasattr(self.container, "clear_overrides"):
+            self.container.clear_overrides()
+
+    def list_overrides(self) -> list[Token[Any]]:
+        """Delegate list_overrides to container."""
+        if hasattr(self.container, "list_overrides"):
+            return self.container.list_overrides()
+        return []
+
+    def __getitem__(self, token: Token[T] | type[T]) -> T:
+        """Get dependency using subscript syntax."""
+        return self.get(token)
 
     def __enter__(self) -> TestScope:
         """Enter test scope."""

--- a/tests/test_async.py
+++ b/tests/test_async.py
@@ -334,3 +334,20 @@ class TestAsyncInjection:
 
         with pytest.raises(CircularDependencyError):
             await container.aget(token_a)
+
+
+def test_subscript_with_async_provider_raises():
+    """Test that subscript access raises for async providers."""
+    container = Container()
+
+    async def async_provider() -> str:
+        return "async result"
+
+    token = Token("async_string", str)
+    container.register(token, async_provider)
+
+    # Subscript should raise (sync context with async provider)
+    with pytest.raises(ResolutionError) as exc_info:
+        _ = container[token]
+
+    assert "Use aget() for async providers" in str(exc_info.value)

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -328,3 +328,111 @@ class TestSingletonLocks:
         # Clean up the second one
         container._cleanup_singleton_lock(obj_token2)
         assert obj_token2 not in container._singleton_locks
+
+
+class TestSubscriptAccess:
+    """Test subscript access syntax for Container."""
+
+    def test_subscript_access_basic(self):
+        """Test basic subscript syntax for dependency resolution."""
+        container = Container()
+
+        class Service:
+            def __init__(self):
+                self.value = 42
+
+        container.register(Service, Service)
+
+        # Subscript access should work like get()
+        service = container[Service]
+        assert isinstance(service, Service)
+        assert service.value == 42
+
+    def test_subscript_access_with_token(self):
+        """Test subscript access with Token instances."""
+        container = Container()
+
+        class Database:
+            pass
+
+        db_token = Token("database", Database)
+        db_instance = Database()
+
+        container.register(db_token, lambda: db_instance)
+
+        # Should work with Token
+        result = container[db_token]
+        assert result is db_instance
+
+    def test_subscript_access_singleton(self):
+        """Test subscript access respects singleton scope."""
+        container = Container()
+
+        class Database:
+            pass
+
+        call_count = 0
+
+        def create_db() -> Database:
+            nonlocal call_count
+            call_count += 1
+            return Database()
+
+        container.register(Database, create_db, scope=Scope.SINGLETON)
+
+        # Multiple subscript accesses should return same instance
+        db1 = container[Database]
+        db2 = container[Database]
+        assert db1 is db2
+        assert call_count == 1
+
+    def test_subscript_access_error(self):
+        """Test subscript access raises ResolutionError for unregistered."""
+        container = Container()
+
+        class Database:
+            pass
+
+        from injx.exceptions import ResolutionError
+
+        with pytest.raises(ResolutionError):
+            _ = container[Database]
+
+    def test_subscript_access_with_overrides(self):
+        """Test subscript access respects context overrides."""
+        container = Container()
+
+        class Database:
+            pass
+
+        original_db = Database()
+        mock_db = Database()
+
+        db_token = Token("database", Database)
+        container.register(db_token, lambda: original_db)
+
+        # Normal access
+        assert container[db_token] is original_db
+
+        # With override
+        with container.use_overrides({db_token: mock_db}):
+            # Subscript should respect override
+            assert container[db_token] is mock_db
+
+        # Back to normal
+        assert container[db_token] is original_db
+
+    def test_subscript_equivalent_to_get(self):
+        """Test that subscript access is equivalent to get()."""
+        container = Container()
+
+        class Thing:
+            pass
+
+        container.register(Thing, Thing, scope=Scope.SINGLETON)
+
+        # Should produce identical results
+        result_get = container.get(Thing)
+        result_subscript = container[Thing]
+
+        assert result_get is result_subscript

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -199,3 +199,25 @@ class TestIntegrationWithContainer:
         # Verify original is unchanged after scope exit
         after_scope = container.get("service")
         assert after_scope == "original"
+
+
+def test_test_scope_subscript_access():
+    """Test subscript access in test scopes."""
+    container = Container()
+
+    class Service:
+        pass
+
+    SERVICE_TOKEN = Token("service", Service)
+    real_service = Service()
+    mock_service = Service()
+
+    container.register(SERVICE_TOKEN, lambda: real_service)
+
+    with container.test_scope() as test:
+        test.override(SERVICE_TOKEN, mock_service)
+
+        # Subscript should work in test scope
+        resolved = test[SERVICE_TOKEN]
+        assert resolved is mock_service
+        assert resolved is not real_service


### PR DESCRIPTION
## Summary

Add Pythonic subscript access syntax (`container[Token]`) for dependency resolution as an ergonomic alternative to `container.get(Token)`.

## Motivation

Inspired by Lagom's clean subscript syntax, this feature improves the developer experience while maintaining Injx's core principles of type safety and explicitness.

## Implementation

### Core Changes

- **Container.__getitem__**: Added subscript access as a thin wrapper around `get()`
- **TestContainer.__getitem__**: Supports subscript access with override semantics
- **TestScope delegation**: Added `get()`, `override()`, `mock()`, `aget()`, `clear_overrides()`, `list_overrides()`, and `__getitem__()` methods
- **Protocol updates**: Updated `ContainerProtocol` and `TestScopeProtocol` with matching signatures
- **Type safety**: Used `@overload` decorators for both `Token[T]` and `type[T]` parameters

### Design Decisions

1. **Sync-only subscript**: `__getitem__` cannot be async in Python, so subscript syntax is synchronous only. Async resolution continues to use explicit `await container.aget(token)`.

2. **Thin wrapper pattern**: `__getitem__` delegates directly to `get()` to maintain consistency and avoid code duplication.

3. **Protocol compliance**: TestScope now properly implements TestScopeProtocol with full delegation to the underlying container.

## Test Coverage

Added 8 comprehensive tests:
- Basic subscript access with types
- Subscript access with Token instances
- Singleton scope verification
- Error handling for unregistered dependencies
- Override mechanism integration
- Equivalence with get() method
- TestScope subscript access
- Async provider error handling

All new tests pass ✅

## Documentation

- Updated README.md with subscript examples
- Updated Container docstrings
- Added CHANGELOG.md entry

## Breaking Changes

None - this is a purely additive feature. All existing code continues to work unchanged.

## Version Impact

This commit will trigger a **minor version bump** (feat commit type) per semantic-release conventions.

## Files Changed

- `src/injx/container.py`: Added `__getitem__` method (43 lines)
- `src/injx/protocols/container.py`: Updated protocols (35 lines)
- `src/injx/testing.py`: Enhanced TestScope delegation (48 lines)
- `tests/test_container.py`: Added TestSubscriptAccess class (108 lines)
- `tests/test_testing.py`: Added subscript test (22 lines)
- `tests/test_async.py`: Added async provider test (17 lines)
- `README.md`: Updated examples (5 lines)
- `CHANGELOG.md`: Added unreleased section (5 lines)

**Total**: 282 lines added across 8 files

## Quality Gates

✅ Formatting (ruff format)
✅ Linting (ruff check - 2 auto-fixes applied)
⚠️ Type checking (pre-existing warnings in testing.py unrelated to this PR)
✅ Tests (8/8 new tests passing)
✅ Backward compatibility (100% maintained)

## Pre-existing Issues

Note: Type checker reports warnings/errors in `testing.py` related to `__enter__`/`__exit__` implementations. These are **pre-existing** and not introduced by this PR. Our changes pass type checking.